### PR TITLE
Changed example pipeline.

### DIFF
--- a/ssjcreator/src/main/AndroidManifest.xml
+++ b/ssjcreator/src/main/AndroidManifest.xml
@@ -53,8 +53,10 @@
             android:theme="@style/AppThemeDefault"
             android:configChanges="orientation|screenSize">
         </activity>
-        <activity android:name=".activity.FeedbackCollectionActivity"
-                  android:configChanges="orientation|screenSize">
+        <activity
+            android:name=".activity.FeedbackCollectionActivity"
+            android:theme="@style/AppThemeDefault"
+            android:configChanges="orientation|screenSize">
         </activity>
         <activity
             android:theme="@style/AppThemeDefault"

--- a/ssjcreator/src/main/assets/demo/pipelines/feedack-collection.example.xml
+++ b/ssjcreator/src/main/assets/demo/pipelines/feedack-collection.example.xml
@@ -155,8 +155,8 @@
     </eventHandler>
     <eventHandler class="hcm.ssj.feedback.FeedbackCollection" id="120849030" delta="0.0" eventTrigger="false">
       <options>
-        <option name="progression" value="2.0" />
-        <option name="regression" value="4.0" />
+        <option name="progression" value="4.0" />
+        <option name="regression" value="6.0" />
       </options>
       <providerList />
       <eventProviderList>

--- a/ssjcreator/src/main/assets/demo/pipelines/feedack-collection.example.xml
+++ b/ssjcreator/src/main/assets/demo/pipelines/feedack-collection.example.xml
@@ -60,7 +60,7 @@
     <consumer class="hcm.ssj.event.ThresholdClassEventSender" id="7561630" delta="0.0" eventTrigger="false">
       <options>
         <option name="classes" value="[low, medium, high]" />
-        <option name="maxDur" value="2.0" />
+        <option name="maxDur" value="0.5" />
         <option name="mean" value="true" />
         <option name="minDiff" value="0.1" />
         <option name="sender" value="ThresholdClassEventSender" />

--- a/ssjcreator/src/main/assets/demo/pipelines/feedback-components.example.xml
+++ b/ssjcreator/src/main/assets/demo/pipelines/feedback-components.example.xml
@@ -75,7 +75,7 @@
   <eventHandlerList>
     <eventHandler class="hcm.ssj.feedback.AuditoryFeedback" id="153979406" delta="0.0" eventTrigger="false">
       <options>
-        <option name="eventName" value="high" />
+        <option name="eventNames" value="high" />
         <option name="lock" value="1000" />
         <option name="audioFile" value="demo/res/blop.mp3" />
         <option name="fromAssets" value="true" />
@@ -88,7 +88,7 @@
     </eventHandler>
     <eventHandler class="hcm.ssj.feedback.VisualFeedback" id="86383043" delta="0.0" eventTrigger="false">
       <options>
-        <option name="eventName" value="medium" />
+        <option name="eventNames" value="medium" />
         <option name="lock" value="1000" />
         <option name="brightness" value="1.0" />
         <option name="duration" value="0" />
@@ -106,7 +106,7 @@
     </eventHandler>
     <eventHandler class="hcm.ssj.feedback.AndroidTactileFeedback" id="60854892" delta="0.0" eventTrigger="false">
       <options>
-        <option name="eventName" value="low" />
+        <option name="eventNames" value="low" />
         <option name="lock" value="1000" />
         <option name="vibrationPattern" value="[0, 500]" />
       </options>
@@ -117,7 +117,7 @@
     </eventHandler>
     <eventHandler class="hcm.ssj.feedback.VisualFeedback" id="225324777" delta="0.0" eventTrigger="false">
       <options>
-        <option name="eventName" value="low" />
+        <option name="eventNames" value="low" />
         <option name="lock" value="1000" />
         <option name="brightness" value="1.0" />
         <option name="duration" value="0" />
@@ -135,7 +135,7 @@
     </eventHandler>
     <eventHandler class="hcm.ssj.feedback.VisualFeedback" id="192803026" delta="0.0" eventTrigger="false">
       <options>
-        <option name="eventName" value="high" />
+        <option name="eventNames" value="high" />
         <option name="lock" value="1000" />
         <option name="brightness" value="1.0" />
         <option name="duration" value="0" />


### PR DESCRIPTION
The behaviour of the "feedack-collection.example.xml" pipeline was rather a misconfiguration then a bug. 
The ThresholdClassEventSender was configured to send a continue event every 2.0 seconds. And the FeedbackCollection's progression time was also set to 2.0 seconds. So it happend that, due to runtime effects, one feedback's last execution time was slightly below the 2.0 second interval and the other feedback's last execution time was slightly above the 2.0 second interval or one feedback has already been triggered, whereas the other one would have been triggered within the next few milliseconds but had no chance. This led to a progression although both feedback's in level 0 seemed to be executed at the same time (which in fact is wrong as there is a difference from few milliseconds due to runtime). 